### PR TITLE
Fixed statement list cannot be empty

### DIFF
--- a/components/syntax_analyzer.py
+++ b/components/syntax_analyzer.py
@@ -387,6 +387,10 @@ class Parser:
             self.__r21_scan()
         elif lexeme == "while":
             self.__r22_while()
+        else:
+            text_1 = f"Statement is missing."
+            text_2 = f"Expected a <Statement>, but found {self.__current_token.lexeme}"
+            raise SyntaxError(f"{text_1}\n{text_2}")
 
     def __r16_compound(self):
         self.debug_print("<Compound> -> { <Statement List> }")

--- a/components/syntax_analyzer.py
+++ b/components/syntax_analyzer.py
@@ -409,6 +409,10 @@ class Parser:
 
             # Match the end of <Assign>, indicated by a semicolon ";".
             self.__match(";")  # Match & Move to the next token
+        else:
+            text_1 = f"Assignment operator is missing."
+            text_2 = f"Expected `=`, but found {self.__current_token.lexeme}"
+            raise SyntaxError(f"{text_1}\n{text_2}")
 
     def __r18_if(self):
         raise NotImplementedError("Must implement this method!")

--- a/tests/test_SA_r11_declaration_list.py
+++ b/tests/test_SA_r11_declaration_list.py
@@ -19,7 +19,7 @@ class DeclarationListTestCase(unittest.TestCase):
 
     def test_1declaration_1id(self):
         # Arrange
-        input_string = "$ $ integer a; $ $"
+        input_string = "$ $ integer a; $ num = 1; $"
         expected_output = True
 
         # Act
@@ -31,7 +31,7 @@ class DeclarationListTestCase(unittest.TestCase):
 
     def test_1declaration_2ids(self):
         # Arrange
-        input_string = "$ $ real a, b; $ $"
+        input_string = "$ $ real a, b; $ num = 1; $"
         expected_output = True
 
         # Act
@@ -43,7 +43,7 @@ class DeclarationListTestCase(unittest.TestCase):
 
     def test_1declaration_3ids(self):
         # Arrange
-        input_string = "$ $ boolean a, b, c; $ $"
+        input_string = "$ $ boolean a, b, c; $ num = 1; $"
         expected_output = True
 
         # Act
@@ -55,7 +55,7 @@ class DeclarationListTestCase(unittest.TestCase):
 
     def test_2declarations_1id(self):
         # Arrange
-        input_string = "$ $ boolean a; boolean b; $ $"
+        input_string = "$ $ boolean a; boolean b; $ num = 1; $"
         expected_output = True
 
         # Act
@@ -67,7 +67,7 @@ class DeclarationListTestCase(unittest.TestCase):
 
     def test_2declarations_2ids(self):
         # Arrange
-        input_string = "$ $ boolean a, b; integer x, y, z; $ $"
+        input_string = "$ $ boolean a, b; integer x, y, z; $ num = 1; $"
         expected_output = True
 
         # Act

--- a/tests/test_SA_r14_statement_list.py
+++ b/tests/test_SA_r14_statement_list.py
@@ -1,0 +1,31 @@
+import unittest
+import os
+from tests.helpers import write_to_file, get_result_from_parser
+
+
+class AssignTestCase(unittest.TestCase):
+    SAMPLE_FILE_PATH = "tests/sample1.txt"
+
+    def setUp(self):
+        if os.path.exists(self.SAMPLE_FILE_PATH):
+            os.remove(self.SAMPLE_FILE_PATH)
+
+    def tearDown(self):
+        if os.path.exists(self.SAMPLE_FILE_PATH):
+            os.remove(self.SAMPLE_FILE_PATH)
+
+    def test_missing_a_statement(self):
+        # Arrange
+        input_string = "$ $ $ $"
+        expected_output = False
+
+        # Act
+        write_to_file(self.SAMPLE_FILE_PATH, input_string)
+        actual_output = get_result_from_parser(self.SAMPLE_FILE_PATH)
+
+        # Assert
+        self.assertEqual(actual_output, expected_output)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_SA_r17_assign_statement.py
+++ b/tests/test_SA_r17_assign_statement.py
@@ -98,9 +98,21 @@ class AssignTestCase(unittest.TestCase):
         # Assert
         self.assertEqual(actual_output, expected_output)
 
-    def test_missing_factor(self):
+    def test_missing_a_factor(self):
         # Arrange
         input_string = "$ $ $ a = b + ; $"
+        expected_output = False
+
+        # Act
+        write_to_file(self.SAMPLE_FILE_PATH, input_string)
+        actual_output = get_result_from_parser(self.SAMPLE_FILE_PATH)
+
+        # Assert
+        self.assertEqual(actual_output, expected_output)
+
+    def test_no_assignment_operator(self):
+        # Arrange
+        input_string = "$ $ $ a; $"
         expected_output = False
 
         # Act

--- a/tests/test_SA_r1_Rat24S.py
+++ b/tests/test_SA_r1_Rat24S.py
@@ -14,9 +14,9 @@ class R1_Rat24STestCase(unittest.TestCase):
         if os.path.exists(self.SAMPLE_FILE_PATH):
             os.remove(self.SAMPLE_FILE_PATH)
 
-    def test_opt_function_definition(self):
+    def test_one_function_definition(self):
         # Arrange
-        input_string = "$ function f1() { } $ $ a = b; $"
+        input_string = "$ function f1() { a = 1; } $ $ a = b; $"
         expected_output = True
 
         # Act
@@ -40,7 +40,7 @@ class R1_Rat24STestCase(unittest.TestCase):
 
     def test_no_declarations_no_function_definitions(self):
         # Arrange
-        input_string = "$ $ $ $"
+        input_string = "$ $ $ num = 1; $"
         expected_output = True
 
         # Act

--- a/tests/test_SA_r3_function_definitions.py
+++ b/tests/test_SA_r3_function_definitions.py
@@ -17,7 +17,7 @@ class FunctionDefinitionsTestCase(unittest.TestCase):
     def test_1fn_0params_0statements(self):
         # Arrange
         input_string = "$ function abc() { } $ $ $"
-        expected_output = True
+        expected_output = False
 
         # Act
         write_to_file(self.SAMPLE_FILE_PATH, input_string)
@@ -28,7 +28,7 @@ class FunctionDefinitionsTestCase(unittest.TestCase):
 
     def test_1fn_0params_1statement(self):
         # Arrange
-        input_string = "$ function abc() { a = 1.1; } $ $ $"
+        input_string = "$ function abc() { a = 1.1; } $ $ num = 1; $"
         expected_output = True
 
         # Act
@@ -40,7 +40,7 @@ class FunctionDefinitionsTestCase(unittest.TestCase):
 
     def test_1fn_1param_1statement(self):
         # Arrange
-        input_string = "$ function abc(amount real) { a = amount; } $ $ $"
+        input_string = "$ function abc(amount real) { a = amount; } $ $ num = 1; $"
         expected_output = True
 
         # Act
@@ -67,6 +67,7 @@ class FunctionDefinitionsTestCase(unittest.TestCase):
                         }
                     $ 
                     $
+                        num = 1;
                     $
                     """
         expected_output = True

--- a/tests/test_SA_r9_body.py
+++ b/tests/test_SA_r9_body.py
@@ -20,7 +20,7 @@ class BodyTestCase(unittest.TestCase):
     
     def test_body(self):
         # Arrange
-        input_string = "$ function abc() { a= b + z; } $ $ $"
+        input_string = "$ function abc() { a= b + z; } $ $ num = 1; $"
         expected_output = True
 
         # Act


### PR DESCRIPTION
# What?
- `<Statement List>` should not be empty.
- `<Statement List>` must have at least one `<Statement>`
- `<Statement>` must throw an exception when there is no `<Compound> | <Assign> | <If> | <Return> | <Print> | <Scan> | <While>`