### PR TITLE
Bugfix/semantic_checker causes code generation to fail when there are parentheses in an expression. For example: "a * (b + 5)"

### DIFF
--- a/components/semantic_checker.py
+++ b/components/semantic_checker.py
@@ -5,19 +5,16 @@ from dataclasses import dataclass
 
 
 class SemanticChecker:
-    ALLOWED_ARITHMETIC_TOKEN_TYPES = [
-        TokenType.IDENTIFIER, TokenType.INTEGER]
-
     def __init__(self, symbol_table: SymbolTable):
         self.__symbol_table = symbol_table
 
     def determine_data_type(self, token: Token) -> TokenType:
         """
         Determines the data type of a given token.
-        
+
         Parameters:
         - token (Token): The token whose data type needs to be determined.
-        
+
         Returns:
         - TokenType: The data type of the token.
         """
@@ -30,14 +27,13 @@ class SemanticChecker:
     def validate_arithmetic_operation(self, lhs: Token, rhs: Token):
         """
         Validates an arithmetic operation between two tokens.
-        
+
         Parameters:
         - lhs (Token): The left-hand side token of the arithmetic operation.
         - rhs (Token): The right-hand side token of the arithmetic operation.
-        
+
         Raises:
-        - TypeError: If the operation involves booleans, if the types don't match,
-                       or if the tokens are not allowed for arithmetic operations.
+        - TypeError: If the operation involves booleans.
         """
         lsh_type = self.determine_data_type(lhs)
         rhs_type = self.determine_data_type(rhs)
@@ -46,12 +42,3 @@ class SemanticChecker:
         if lsh_type == TokenType.BOOLEAN or rhs_type == TokenType.BOOLEAN:
             raise TypeError(
                 "No arithmetic operations are allowed for booleans")
-        # Rule 3: No arithmetic operations are allowed KEYWORDS
-        elif (lhs.token_type not in self.ALLOWED_ARITHMETIC_TOKEN_TYPES or
-              rhs.token_type not in self.ALLOWED_ARITHMETIC_TOKEN_TYPES
-              ):
-              raise TypeError(
-                f"No arithmetic operations are allowed between {lhs.token_type} and {rhs.token_type}")
-        # Rule 2: The types must match for arithmetic operations (no conversions)
-        elif lsh_type != rhs_type:
-            raise TypeError("Data types do not match")

--- a/tests/unit/test_CG_r25_expression.py
+++ b/tests/unit/test_CG_r25_expression.py
@@ -291,6 +291,117 @@ class ExpressionTestCase(unittest.TestCase):
         # Assert
         self.assertEqual(actual_output, expected_output)
 
+    def test_2ids_2integers(self):
+        # Arrange
+        input_string = """
+            $
+            $
+                integer a, b, sum;
+            $
+                a = 1;
+                b = 2;
+                sum = a * b * 8 * 2;
+            $
+        """
+
+        string_builder = StringIO()
+        string_builder.write("PUSHI 1\n")
+        string_builder.write("POPM 5000\n")
+        string_builder.write("PUSHI 2\n")
+        string_builder.write("POPM 5001\n")
+        string_builder.write("PUSHM 5000\n")
+        string_builder.write("PUSHM 5001\n")
+        string_builder.write("M\n")
+        string_builder.write("PUSHI 8\n")
+        string_builder.write("M\n")
+        string_builder.write("PUSHI 2\n")
+        string_builder.write("M\n")
+        string_builder.write("POPM 5002\n")
+        expected_output = string_builder.getvalue()
+
+        # Act
+        write_to_file(self.SAMPLE_FILE_PATH, input_string)
+        actual_output = get_result_from_code_generator(self.SAMPLE_FILE_PATH)
+
+        # Assert
+        self.assertEqual(actual_output, expected_output)
+
+    def test_many_expressions(self):
+        # Arrange
+        input_string = """
+            $
+            $
+                integer a, b, sum;
+            $
+                a = 1;
+                b = 2;
+                sum = a * (b + 8) / (2 - a);
+            $
+        """
+
+        string_builder = StringIO()
+        string_builder.write("PUSHI 1\n")
+        string_builder.write("POPM 5000\n")
+        string_builder.write("PUSHI 2\n")
+        string_builder.write("POPM 5001\n")
+        string_builder.write("PUSHM 5000\n")
+        string_builder.write("PUSHM 5001\n")
+        string_builder.write("PUSHI 8\n")
+        string_builder.write("A\n")
+        string_builder.write("M\n")
+        string_builder.write("PUSHI 2\n")
+        string_builder.write("PUSHM 5000\n")
+        string_builder.write("S\n")
+        string_builder.write("D\n")
+        string_builder.write("POPM 5002\n")
+        expected_output = string_builder.getvalue()
+
+        # Act
+        write_to_file(self.SAMPLE_FILE_PATH, input_string)
+        actual_output = get_result_from_code_generator(self.SAMPLE_FILE_PATH)
+
+        # Assert
+        self.assertEqual(actual_output, expected_output)
+
+    def test_nested(self):
+        # Arrange
+        input_string = """
+            $
+            $
+                integer a, b, sum;
+            $
+                a = 1;
+                b = 2;
+                sum = a * (9 / 3 * (a - b)) - 2);
+            $
+        """
+
+        string_builder = StringIO()
+        string_builder.write("PUSHI 1\n")
+        string_builder.write("POPM 5000\n")
+        string_builder.write("PUSHI 2\n")
+        string_builder.write("POPM 5001\n")
+        string_builder.write("PUSHM 5000\n")
+        string_builder.write("PUSHI 9\n")
+        string_builder.write("PUSHI 3\n")
+        string_builder.write("D\n")
+        string_builder.write("PUSHM 5000\n")
+        string_builder.write("PUSHM 5001\n")
+        string_builder.write("S\n")
+        string_builder.write("M\n")
+        string_builder.write("M\n")
+        string_builder.write("PUSHI 2\n")
+        string_builder.write("S\n")
+        string_builder.write("POPM 5002\n")
+        expected_output = string_builder.getvalue()
+
+        # Act
+        write_to_file(self.SAMPLE_FILE_PATH, input_string)
+        actual_output = get_result_from_code_generator(self.SAMPLE_FILE_PATH)
+
+        # Assert
+        self.assertEqual(actual_output, expected_output)
+
     def test_boolean_addition_not_allowed(self):
         # Arrange
         input_string = """
@@ -303,6 +414,40 @@ class ExpressionTestCase(unittest.TestCase):
         """
 
         expected_output = ""
+
+        # Act
+        write_to_file(self.SAMPLE_FILE_PATH, input_string)
+        actual_output = get_result_from_code_generator(self.SAMPLE_FILE_PATH)
+
+        # Assert
+        self.assertEqual(actual_output, expected_output)
+
+    def test_expression_with_parenthesis(self):
+        # Arrange
+        input_string = """
+            $
+            $
+                integer a, b, sum;
+            $
+                a = 1;
+                b = 2;
+                sum = a * (b + 8);
+            $
+        """
+
+        string_builder = StringIO()
+        string_builder.write("PUSHI 1\n")
+        string_builder.write("POPM 5000\n")
+        string_builder.write("PUSHI 2\n")
+        string_builder.write("POPM 5001\n")
+        string_builder.write("PUSHM 5000\n")
+        
+        string_builder.write("PUSHM 5001\n")
+        string_builder.write("PUSHI 8\n")
+        string_builder.write("A\n")
+        string_builder.write("M\n")
+        string_builder.write("POPM 5002\n")
+        expected_output = string_builder.getvalue()
 
         # Act
         write_to_file(self.SAMPLE_FILE_PATH, input_string)


### PR DESCRIPTION
# What
- Fixed a bug that causes code generation to fail when there are parenthesizes in an expression. For example: "a * (b + 5)"
- Add more test cases for nested expressions