### PR TITLE
Semantic rule: assigning an integer to a boolean variable is not allowed.

### DIFF
--- a/components/symbol_table.py
+++ b/components/symbol_table.py
@@ -43,7 +43,7 @@ class SymbolTable:
         self.__current_address += 1
         return symbol.address
 
-    def get(self, identifier) -> Optional[Symbol]:
+    def get(self, identifier) -> Symbol:
         """
         Retrieves a symbol from the symbol table.
 
@@ -51,9 +51,15 @@ class SymbolTable:
         - identifier (str): The identifier of the symbol to retrieve.
 
         Returns:
-        - Optional[Symbol]: The Symbol object if found, or None if the symbol is not in the table.
+        - Symbol: The symbol associated with the given identifier.
+
+        Raises:
+        - NameError: If the identifier is not found in the table.
         """
-        return self.__entries.get(identifier)
+        symbol = self.__entries.get(identifier)
+        if symbol == None:
+            raise NameError(f"Variable '{identifier}' is not defined.") 
+        return symbol
 
     def get_address(self, identifier) -> int:
         """
@@ -68,11 +74,8 @@ class SymbolTable:
         Raises:
         - NameError: If the variable is not defined in the symbol table.
         """
-        try:
-            symbol = self.__entries.get(identifier)
-            return symbol.address
-        except:
-            raise NameError(f"Variable '{identifier}' is not defined.")
+        symbol = self.__entries.get(identifier)
+        return symbol.address
 
     def print_table(self):
         """

--- a/components/syntax_analyzer.py
+++ b/components/syntax_analyzer.py
@@ -465,7 +465,7 @@ class Parser:
         <Assign> -> <Identifier> = <Expression> ;
         """
         if self.__current_token.token_type == TokenType.IDENTIFIER:
-            rhs_token = self.__current_token # The right hand side <Identifier>
+            lhs_token = self.__current_token # The left hand side <Identifier>
 
         self.__log_current_token()
         self.__log("<Statement> -> <Assign>")
@@ -480,15 +480,15 @@ class Parser:
 
             if self.__code_generation_enabled:
                 # Check type data type match
-                rhs_datatype = self.__semantic_checker.determine_data_type(rhs_token)
-                if rhs_datatype not in set_of_data_types:
+                lhs_datatype = self.__semantic_checker.determine_data_type(lhs_token)
+                if lhs_datatype not in set_of_data_types:
                     result = ', '.join(str(e.name) for e in set_of_data_types)
                     text1 = "Data types do not match"
-                    text2 = f"Cannot assign {result} to a {rhs_datatype.name} variable"
+                    text2 = f"Cannot assign {result} to a {lhs_datatype.name} variable"
                     raise SyntaxError(f"{text1}\n{text2}")
 
                 # Generate instructions
-                address = self.__symbol_table.get_address(rhs_token.lexeme)
+                address = self.__symbol_table.get_address(lhs_token.lexeme)
                 self.__instruction_table.generate_instruction(Operator.POPM, address)
 
             # Match the end of <Assign>, indicated by a semicolon ";".

--- a/components/syntax_analyzer.py
+++ b/components/syntax_analyzer.py
@@ -768,8 +768,6 @@ class Parser:
         temp_token_types = self.__r26b_term_prime(factor)
         set_of_data_types.update(temp_token_types)
 
-        # TODO: Right now, we cannot return an expression like this: 8 * 5
-        # Maybe in order to do it, we might need to build an AST tree.
         return factor, set_of_data_types
 
     def __r26b_term_prime(self, prev_factor):

--- a/components/syntax_analyzer.py
+++ b/components/syntax_analyzer.py
@@ -465,7 +465,7 @@ class Parser:
         <Assign> -> <Identifier> = <Expression> ;
         """
         if self.__current_token.token_type == TokenType.IDENTIFIER:
-            save = self.__current_token.lexeme
+            rhs_token = self.__current_token # The right hand side <Identifier>
 
         self.__log_current_token()
         self.__log("<Statement> -> <Assign>")
@@ -476,11 +476,19 @@ class Parser:
         if self.__current_token.lexeme == "=":
             self.__log_current_token()
             self.__match(self.__current_token.lexeme)  # Move to the next token
-            self.__r25a_expression()
+            set_of_data_types = self.__r25a_expression()
 
-            # Generate instructions
             if self.__code_generation_enabled:
-                address = self.__symbol_table.get_address(save)
+                # Check type data type match
+                rhs_datatype = self.__semantic_checker.determine_data_type(rhs_token)
+                if rhs_datatype not in set_of_data_types:
+                    result = ', '.join(str(e.name) for e in set_of_data_types)
+                    text1 = "Data types do not match"
+                    text2 = f"Cannot assign {result} to a {rhs_datatype.name} variable"
+                    raise SyntaxError(f"{text1}\n{text2}")
+
+                # Generate instructions
+                address = self.__symbol_table.get_address(rhs_token.lexeme)
                 self.__instruction_table.generate_instruction(Operator.POPM, address)
 
             # Match the end of <Assign>, indicated by a semicolon ";".
@@ -699,14 +707,22 @@ class Parser:
 
         self.__log("<Expression> -> <Term> <Expression Prime>")
 
-        term = self.__r26a_term()
-        self.__r25b_expression_prime(term)
+        set_of_data_types = set()
+        term, temp_token_types = self.__r26a_term()
+        set_of_data_types.update(temp_token_types)
+        temp_token_types = self.__r25b_expression_prime(term)
+
+        # Insert elements from set2 into set1
+        set_of_data_types.update(temp_token_types)
+        return set_of_data_types
 
     def __r25b_expression_prime(self, prev_term):
         """
         Applies the production rule 25b: 
         <Expression Prime> -> + <Term> <Expression Prime> | - <Term> <Expression Prime> | ε
         """
+        set_of_data_types = set()
+
         # Check for '+' or '-' case
         if self.__current_token.lexeme == "+" or self.__current_token.lexeme == "-":
             if self.__current_token.lexeme == "+":
@@ -724,14 +740,19 @@ class Parser:
             if self.__current_token.lexeme != "(":
                 self.__log_current_token()
 
-            term = self.__r26a_term()
+            term, temp_token_types = self.__r26a_term()
+            set_of_data_types.update(temp_token_types)
+
             if self.__code_generation_enabled:
                 self.__semantic_checker.validate_arithmetic_operation(prev_term, term)
                 self.__instruction_table.generate_instruction(operation)
-            self.__r25b_expression_prime(term)
+            temp_token_types = self.__r25b_expression_prime(term)
+            set_of_data_types.update(temp_token_types)
         # Handle Epsilon case
         else:
             self.__log("<Expression Prime> -> ε")
+        
+        return set_of_data_types
 
     def __r26a_term(self):
         """
@@ -740,18 +761,23 @@ class Parser:
         """
         self.__log("<Term> -> <Factor> <Term Prime>")
 
-        factor = self.__r27_factor()
-        self.__r26b_term_prime(factor)
+        set_of_data_types = set()
+
+        factor, temp_token_types = self.__r27_factor()
+        set_of_data_types.update(temp_token_types)
+        temp_token_types = self.__r26b_term_prime(factor)
+        set_of_data_types.update(temp_token_types)
 
         # TODO: Right now, we cannot return an expression like this: 8 * 5
         # Maybe in order to do it, we might need to build an AST tree.
-        return factor
+        return factor, set_of_data_types
 
     def __r26b_term_prime(self, prev_factor):
         """
         Applies the production rule 26b:
         <Term Prime> -> * <Factor> <Term Prime> | / <Factor> <Term Prime> | ε
         """
+        set_of_data_types = set()
         # Check for '*' or '/' case
         if self.__current_token.lexeme == "*" or self.__current_token.lexeme == "/":
             if self.__current_token.lexeme == "*":
@@ -773,16 +799,21 @@ class Parser:
                 self.__log_current_token()
 
             
-            factor = self.__r27_factor()
+            factor, temp_token_types = self.__r27_factor()
+            set_of_data_types.update(temp_token_types)
+
             if self.__code_generation_enabled:
                 self.__semantic_checker.validate_arithmetic_operation(prev_factor, factor)
                 self.__instruction_table.generate_instruction(operation)
 
             # Apply production rules for Factor and Term Prime recursively
-            self.__r26b_term_prime(factor)
+            temp_token_types = self.__r26b_term_prime(factor)
+            set_of_data_types.update(temp_token_types)
         # Handle Epsilon case
         else:
             self.__log("<Term Prime> -> ε")
+
+        return set_of_data_types
 
     def __r27_factor(self):
         """
@@ -801,7 +832,7 @@ class Parser:
         else:
             text_to_print = "<Factor> ->"
         
-        text, token = self.__r28_primary()
+        text, token, set_of_data_types = self.__r28_primary()
 
         if text:
             text_to_print = f"{text_to_print} {text}"
@@ -818,7 +849,7 @@ class Parser:
                 address = self.__symbol_table.get_address(token.lexeme)
                 self.__instruction_table.generate_instruction(Operator.PUSHM, address)
         
-        return token
+        return token, set_of_data_types
 
     def __r28_primary(self):
         """
@@ -831,10 +862,15 @@ class Parser:
             str: The text representing the parsed primary token
         """
         text = ""
+        set_of_data_types = set()        
         token = self.__current_token
 
         # Case 1: IDENTIFIER
         if self.__current_token.token_type == TokenType.IDENTIFIER:
+            if self.__code_generation_enabled:
+                datatype = self.__semantic_checker.determine_data_type(self.__current_token)
+
+                set_of_data_types.add(datatype)
             self.__match(self.__current_token.lexeme)  # Move to the next token
             text = self.__r28b_primary_prime()
             text = f"<Identifier> {text}"
@@ -842,10 +878,12 @@ class Parser:
         elif (self.__current_token.token_type == TokenType.INTEGER
                 or self.__current_token.token_type == TokenType.REAL
             ):
+            set_of_data_types.add(self.__current_token.token_type)
             text = f"<{self.__current_token.token_type.name}>"
             self.__match(self.__current_token.lexeme)  # Move to the next token
         # Case 3: "true" or "false"
         elif (self.__current_token.lexeme == "true" or self.__current_token.lexeme == "false"):
+            set_of_data_types.add(TokenType.BOOLEAN)
             token.token_type = TokenType.BOOLEAN
             text = self.__current_token.lexeme
             self.__match(self.__current_token.lexeme)  # Move to the next token
@@ -854,7 +892,7 @@ class Parser:
             self.__log("<Primary Prime> -> ( <Expression> )")
             self.__log_current_token()
             self.__match(self.__current_token.lexeme)  # Move to the next token
-            self.__r25a_expression()
+            set_of_data_types.update(self.__r25a_expression())
             self.__log_current_token()
             self.__match(")")  # Match and Move to the next token
         # Handle error: The current token does not match any expected types
@@ -862,7 +900,7 @@ class Parser:
             raise SyntaxError(
                 f'Expected `ID, Number, (Expression), boolean`, but found {self.__current_token.token_type}')
 
-        return text, token
+        return text, token, set_of_data_types
 
     def __r28b_primary_prime(self):
         """

--- a/tests/unit/test_CG_r17_assign.py
+++ b/tests/unit/test_CG_r17_assign.py
@@ -71,18 +71,110 @@ class AssignTestCase(unittest.TestCase):
         # Assert
         self.assertEqual(actual_output, expected_output)
 
-    def test_variable_already_defined(self):
+    def test_arithmetic_expression_to_intvar_1(self):
         # Arrange
         input_string = """
             $
             $
-                boolean success;
-                boolean success;
+                integer a;
             $
-                success = true;
+                a = (5 + 7);
             $
         """
+        string_builder = StringIO()
+        string_builder.write("PUSHI 5\n")
+        string_builder.write("PUSHI 7\n")
+        string_builder.write("A\n")
+        string_builder.write("POPM 5000\n")
+        expected_output = string_builder.getvalue()
 
+        # Act
+        write_to_file(self.SAMPLE_FILE_PATH, input_string)
+        actual_output = get_result_from_code_generator(self.SAMPLE_FILE_PATH)
+
+        # Assert
+        self.assertEqual(actual_output, expected_output)
+
+    def test_arithmetic_expression_to_intvar_2(self):
+        # Arrange
+        input_string = """
+            $
+            $
+                integer a, b;                
+            $
+                a = (5 + 7) / b;
+            $
+        """
+        string_builder = StringIO()
+        string_builder.write("PUSHI 5\n")
+        string_builder.write("PUSHI 7\n")
+        string_builder.write("A\n")
+        string_builder.write("PUSHM 5001\n")
+        string_builder.write("D\n")
+        string_builder.write("POPM 5000\n")
+        expected_output = string_builder.getvalue()
+
+        # Act
+        write_to_file(self.SAMPLE_FILE_PATH, input_string)
+        actual_output = get_result_from_code_generator(self.SAMPLE_FILE_PATH)
+
+        # Assert
+        self.assertEqual(actual_output, expected_output)
+
+    def test_boolvalue_in_parentheses_to_boolvar(self):
+        # Arrange
+        input_string = """
+            $
+            $
+                boolean a;
+            $
+                a = ((((true))));
+            $
+        """
+        string_builder = StringIO()
+        string_builder.write("PUSHI 1\n")
+        string_builder.write("POPM 5000\n")
+        expected_output = string_builder.getvalue()
+
+        # Act
+        write_to_file(self.SAMPLE_FILE_PATH, input_string)
+        actual_output = get_result_from_code_generator(self.SAMPLE_FILE_PATH)
+
+        # Assert
+        self.assertEqual(actual_output, expected_output)
+
+    def test_intvar_to_intvar(self):
+        # Arrange
+        input_string = """
+            $
+            $
+                integer a, b;
+            $
+                a = b;
+            $
+        """
+        string_builder = StringIO()
+        string_builder.write("PUSHM 5001\n")
+        string_builder.write("POPM 5000\n")
+        expected_output = string_builder.getvalue()
+
+        # Act
+        write_to_file(self.SAMPLE_FILE_PATH, input_string)
+        actual_output = get_result_from_code_generator(self.SAMPLE_FILE_PATH)
+
+        # Assert
+        self.assertEqual(actual_output, expected_output)
+
+    def test_int_to_boolvar_not_allowed(self):
+        # Arrange
+        input_string = """
+            $
+            $
+                boolean a;
+            $
+                a = 5;
+            $
+        """
         expected_output = ""
 
         # Act
@@ -92,7 +184,83 @@ class AssignTestCase(unittest.TestCase):
         # Assert
         self.assertEqual(actual_output, expected_output)
 
-   
+    def test_intvar_to_boolvar_not_allowed(self):
+        # Arrange
+        input_string = """
+            $
+            $
+                integer a;
+                boolean b;
+            $
+                b = a;
+            $
+        """
+        expected_output = ""
+
+        # Act
+        write_to_file(self.SAMPLE_FILE_PATH, input_string)
+        actual_output = get_result_from_code_generator(self.SAMPLE_FILE_PATH)
+
+        # Assert
+        self.assertEqual(actual_output, expected_output)
+
+    def test_boolvar_to_intvar_not_allowed(self):
+        # Arrange
+        input_string = """
+            $
+            $
+                integer a;
+                boolean b;
+            $
+                a = b;
+            $
+        """
+        expected_output = ""
+
+        # Act
+        write_to_file(self.SAMPLE_FILE_PATH, input_string)
+        actual_output = get_result_from_code_generator(self.SAMPLE_FILE_PATH)
+
+        # Assert
+        self.assertEqual(actual_output, expected_output)
+
+    def test_bool_to_intvar_not_allowed(self):
+        # Arrange
+        input_string = """
+            $
+            $
+                integer a;
+            $
+                a = true;
+            $
+        """
+        expected_output = ""
+
+        # Act
+        write_to_file(self.SAMPLE_FILE_PATH, input_string)
+        actual_output = get_result_from_code_generator(self.SAMPLE_FILE_PATH)
+
+        # Assert
+        self.assertEqual(actual_output, expected_output)
+
+    def test_arithmetic_expression_to_boolvar_not_allowed(self):
+        # Arrange
+        input_string = """
+            $
+            $
+                boolean a;
+            $
+                a = (5 + 7);
+            $
+        """
+        expected_output = ""
+
+        # Act
+        write_to_file(self.SAMPLE_FILE_PATH, input_string)
+        actual_output = get_result_from_code_generator(self.SAMPLE_FILE_PATH)
+
+        # Assert
+        self.assertEqual(actual_output, expected_output)
 
 
 if __name__ == '__main__':

--- a/tests/unit/test_symbol_table.py
+++ b/tests/unit/test_symbol_table.py
@@ -1,0 +1,60 @@
+import unittest
+import os
+from io import StringIO
+from tests.unit.helpers import write_to_file, get_result_from_code_generator
+
+
+class SymbolTableTestCase(unittest.TestCase):
+    SAMPLE_FILE_PATH = "tests/sample1.txt"
+
+    def setUp(self):
+        if os.path.exists(self.SAMPLE_FILE_PATH):
+            os.remove(self.SAMPLE_FILE_PATH)
+
+    def tearDown(self):
+        if os.path.exists(self.SAMPLE_FILE_PATH):
+            os.remove(self.SAMPLE_FILE_PATH)
+
+    def test_variable_not_defined(self):
+        # Arrange
+        input_string = """
+            $
+            $
+            $
+                success = true;
+            $
+        """
+
+        expected_output = ""
+
+        # Act
+        write_to_file(self.SAMPLE_FILE_PATH, input_string)
+        actual_output = get_result_from_code_generator(self.SAMPLE_FILE_PATH)
+
+        # Assert
+        self.assertEqual(actual_output, expected_output)
+
+    def test_variable_already_defined(self):
+        # Arrange
+        input_string = """
+            $
+            $
+                boolean success;
+                boolean success;
+            $
+                success = true;
+            $
+        """
+
+        expected_output = ""
+
+        # Act
+        write_to_file(self.SAMPLE_FILE_PATH, input_string)
+        actual_output = get_result_from_code_generator(self.SAMPLE_FILE_PATH)
+
+        # Assert
+        self.assertEqual(actual_output, expected_output)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# What?
- Added semantic rule: assigning an integer to a boolean is not allowed.
- Added test case to test data type match

# Why?
- This is the requirement of the assignment 3. For example:
```python
boolean a;
a = false # OK
a = (((true))) # OK
a = (5 + 6) / 2  # Error. Data type do not match
```